### PR TITLE
Better fix for building on mac

### DIFF
--- a/delaycut.pro
+++ b/delaycut.pro
@@ -46,6 +46,7 @@ macx {
   ICON = src/icon.icns
   #If you are using qt from brew, remove line below
   QMAKE_APPLE_DEVICE_ARCHS = x86_64 arm64
+  QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.15
 }
 
 QMAKE_CLEAN += qrc_icon_ico.cpp \

--- a/delaycut.pro
+++ b/delaycut.pro
@@ -44,6 +44,8 @@ win32-msvc* {
 
 macx {
   ICON = src/icon.icns
+  #If you are using qt from brew, remove line below
+  QMAKE_APPLE_DEVICE_ARCHS = x86_64 arm64
 }
 
 QMAKE_CLEAN += qrc_icon_ico.cpp \

--- a/src/dc_types.h
+++ b/src/dc_types.h
@@ -17,13 +17,6 @@
     along with DelayCut.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/*fix apple sillicon build*/
-
-#ifdef __APPLE__
-#define stat64 stat
-#define fstat64 fstat
-#endif
-
 #ifndef DC_TYPES_H
 #define DC_TYPES_H
 

--- a/src/delayac3.cpp
+++ b/src/delayac3.cpp
@@ -30,6 +30,15 @@
 #include <QFileInfo>
 #include <QThread>
 
+/* Probably better fix for building on mac */
+#if defined(__APPLE__)
+#include <sys/cdefs.h>
+#endif
+#if defined(__APPLE__) && defined(_DARWIN_FEATURE_ONLY_64_BIT_INODE)
+#define stat64 stat
+#define fstat64 fstat
+#endif
+
 #define NUMREAD 8
 #define MAXBYTES_PER_FRAME 2*1280
 #define MAXLOGERRORS 100


### PR DESCRIPTION
The first fix was inspired by this pr https://github.com/rpm-software-management/rpm/pull/1775, but I didn't check the comments, so that fix is out of date. And the new fix was copypasted from here https://github.com/rpm-software-management/rpm/pull/1897
There is also a universal build, I don't know why macdeployqt can't create a .dmg, so there is only a .zip
[delaycut-1.4.3.10-Qt6-MacOS-Universal.zip](https://github.com/darealshinji/delaycut/files/15240314/delaycut-1.4.3.10-Qt6-MacOS-Universal.zip)
